### PR TITLE
fix(cache): make RedisCacheService.GetList cluster-safe (per-key GET)

### DIFF
--- a/src/Core/Bermuda.Core.Cache/Service/RedisCacheService.cs
+++ b/src/Core/Bermuda.Core.Cache/Service/RedisCacheService.cs
@@ -34,15 +34,21 @@ namespace Bermuda.Core.Cache
 
         public Dictionary<string, T> GetList<T>(string pattern, int? index = null)
         {
-            var endpoints = _connection.GetEndPoints(true);
-            var server = _connection.GetServer(endpoints[0]);
-            var db = index.HasValue ? _connection.GetDatabase(index.Value) : _database;
-            var keys = server.Keys(db.Database, pattern).ToArray();
-            var values = db.StringGet(keys);
-
-            var result = keys
-                .Select((key, i) => new { key, value = values[i] })
-                .ToDictionary(kv => kv.key.ToString(), kv => ConvertRedisValue<T>(kv.value));
+            var result = new Dictionary<string, T>();
+            var endpoints = _connection?.GetEndPoints(true);
+            if (endpoints is null) return result;
+            var db = index.HasValue ? _connection?.GetDatabase(index.Value) : _database;
+            if (db is null) return result;
+            foreach (var endpoint in endpoints)
+            {
+                var server = _connection?.GetServer(endpoint);
+                if (server is null) continue;
+                // Read one key at a time: a multi-key StringGet (MGET) throws CROSSSLOT on a
+                // Redis cluster (keys hash to different slots). Single-key GET is slot-safe.
+                // Iterate every endpoint so all cluster nodes' slots are covered (mirrors RemoveAll).
+                foreach (var key in server.Keys(db.Database, pattern))
+                    result[key.ToString()] = ConvertRedisValue<T>(db.StringGet(key));
+            }
             return result;
         }
 


### PR DESCRIPTION
## What
`RedisCacheService.GetList` issued a single multi-key `StringGet` (MGET). On a Redis **cluster** (prod ElastiCache Serverless) the matched keys hash to different slots → **CROSSSLOT** throw.

Rewrites `GetList` to iterate endpoints and read **one key at a time** — slot-safe — mirroring the `RemoveAll` cluster-safe fix on the base branch.

## Why
Root cause of a prod incident (2026-07-06): rating-api HealthCheck V2 collapsed to a single red slot because `GetHealthCheck` → `GetList(pattern)` threw CROSSSLOT (wrapped as BusinessException, rethrown, collapsing the whole response). Single-node dev/test were unaffected (MGET works there).

## Scope
- One method changed (`GetList`); IL-diff vs the previously-vendored DLL confirmed only `GetList` (+ its old LINQ-generated helper types) changed.
- Rebuilt DLL vendored into rating-api (MR !3058, merged to main; prod reconciled via CI).

## Base branch note
Based on `fix/removeall-crossslot-cluster-safe` (the branch the deployed DLL was built from) so this diff is **only** the GetList commit. Note: neither branch is on `master` yet — infra `master` is ~9 commits behind what's actually built/vendored to prod; a separate cleanup should reconcile `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)