### PR TITLE
fix(cache): cluster-safe RedisCacheService (per-key GetList + RemoveAll)

### DIFF
--- a/src/Core/Bermuda.Core.Cache/Service/RedisCacheService.cs
+++ b/src/Core/Bermuda.Core.Cache/Service/RedisCacheService.cs
@@ -34,15 +34,21 @@ namespace Bermuda.Core.Cache
 
         public Dictionary<string, T> GetList<T>(string pattern, int? index = null)
         {
-            var endpoints = _connection.GetEndPoints(true);
-            var server = _connection.GetServer(endpoints[0]);
-            var db = index.HasValue ? _connection.GetDatabase(index.Value) : _database;
-            var keys = server.Keys(db.Database, pattern).ToArray();
-            var values = db.StringGet(keys);
-
-            var result = keys
-                .Select((key, i) => new { key, value = values[i] })
-                .ToDictionary(kv => kv.key.ToString(), kv => ConvertRedisValue<T>(kv.value));
+            var result = new Dictionary<string, T>();
+            var endpoints = _connection?.GetEndPoints(true);
+            if (endpoints is null) return result;
+            var db = index.HasValue ? _connection?.GetDatabase(index.Value) : _database;
+            if (db is null) return result;
+            foreach (var endpoint in endpoints)
+            {
+                var server = _connection?.GetServer(endpoint);
+                if (server is null) continue;
+                // Read one key at a time: a multi-key StringGet (MGET) throws CROSSSLOT on a
+                // Redis cluster (keys hash to different slots). Single-key GET is slot-safe.
+                // Iterate every endpoint so all cluster nodes' slots are covered (mirrors RemoveAll).
+                foreach (var key in server.Keys(db.Database, pattern))
+                    result[key.ToString()] = ConvertRedisValue<T>(db.StringGet(key));
+            }
             return result;
         }
 
@@ -67,12 +73,16 @@ namespace Bermuda.Core.Cache
         public void RemoveAll(string pattern = "*", int? index = null)
         {
             var endpoints = _connection?.GetEndPoints(true);
+            if (endpoints is null) return;
             foreach (var endpoint in endpoints)
             {
                 var server = _connection?.GetServer(endpoint);
                 var db = index.HasValue ? _connection?.GetDatabase(index.Value) : _database;
-                var keys = server?.Keys(db.Database, pattern)?.ToArray();
-                db?.KeyDelete(keys);
+                if (server is null || db is null) continue;
+                // Delete one key at a time: a multi-key KeyDelete throws CROSSSLOT on a
+                // Redis cluster (keys hash to different slots). Single-key DEL is slot-safe.
+                foreach (var key in server.Keys(db.Database, pattern))
+                    db.KeyDelete(key);
             }
         }
 


### PR DESCRIPTION
## What
Rewrites `RedisCacheService.GetList` and `RemoveAll` to iterate endpoints and operate **one key at a time**. Both previously issued multi-key ops (`StringGet` MGET / multi-key `KeyDelete`) which throw **CROSSSLOT** on a Redis **cluster** (keys hash to different slots).

## Why
Root cause of the 2026-07-06 prod incident: rating-api HealthCheck V2 collapsed to a single red slot because `GetHealthCheck` → `GetList(pattern)` threw CROSSSLOT on prod ElastiCache Serverless (cluster), got wrapped as BusinessException, and rethrown → collapsed the whole response. Single-node dev/test were unaffected (MGET works there). `RemoveAll` had the same latent bug.

## Scope — source-only, cache-only
- **Only `src/Core/Bermuda.Core.Cache/Service/RedisCacheService.cs`** (2 methods). Cherry-picked clean off master — no unrelated commits.
- Already vendored to consumers and prod-verified: rating-api MR !3058 (merged to main, prod reconciled via CI). dev/test backfills open (!3059/!3060).
- Committed `lib/*.dll` on master are left as-is (they're stale across the board — this repo has been built+vendored off branches for months). Reconciling master's binaries is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)